### PR TITLE
5.0にアップグレード

### DIFF
--- a/UsfPluginProject/Plugins/Sketch/Source/Sketch/Private/Sketch.cpp
+++ b/UsfPluginProject/Plugins/Sketch/Source/Sketch/Private/Sketch.cpp
@@ -7,7 +7,7 @@
 
 void FSketchModule::StartupModule()
 {
-#if (ENGINE_MINOR_VERSION >= 21)
+#if (ENGINE_MINOR_VERSION >= 21 || ENGINE_MAJOR_VERSION >= 5)
     FString PluginDirectory = IPluginManager::Get().FindPlugin(TEXT("Sketch"))->GetBaseDir();
     if(!AllShaderSourceDirectoryMappings().Contains("/Plugins/Sketch"))
         AddShaderSourceDirectoryMapping("/Plugins/Sketch", PluginDirectory);

--- a/UsfPluginProject/Plugins/Sketch/Source/Sketch/Private/SketchShader.cpp
+++ b/UsfPluginProject/Plugins/Sketch/Source/Sketch/Private/SketchShader.cpp
@@ -1,5 +1,5 @@
 #include "SketchShader.h"
-
+#include <Runtime/RenderCore/Public/ShaderCompilerCore.h>
 
 FSketchShaderVS::FSketchShaderVS(const ShaderMetaType::CompiledShaderInitializerType& Initializer)
 	: FGlobalShader(Initializer)
@@ -12,13 +12,6 @@ void FSketchShaderVS::ModifyCompilationEnvironment(const FGlobalShaderPermutatio
 	OutEnvironment.CompilerFlags.Add(CFLAG_StandardOptimization);
 }
 
-bool FSketchShaderVS::Serialize(FArchive& Ar)
-{
-    return FGlobalShader::Serialize(Ar);
-}
-
-
-
 FSketchShaderPS::FSketchShaderPS(const ShaderMetaType::CompiledShaderInitializerType& Initializer)
 	: FGlobalShader(Initializer)
 {
@@ -28,11 +21,6 @@ void FSketchShaderPS::ModifyCompilationEnvironment(const FGlobalShaderPermutatio
 {
 	FGlobalShader::ModifyCompilationEnvironment(Parameters, OutEnvironment);
 	OutEnvironment.CompilerFlags.Add(CFLAG_StandardOptimization);
-}
-
-bool FSketchShaderPS::Serialize(FArchive& Ar)
-{
-    return FGlobalShader::Serialize(Ar);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/UsfPluginProject/Plugins/Sketch/Source/Sketch/Public/SketchShader.h
+++ b/UsfPluginProject/Plugins/Sketch/Source/Sketch/Public/SketchShader.h
@@ -12,10 +12,9 @@ public:
 	FSketchShaderVS() {}
 	explicit FSketchShaderVS(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
 
-	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES2); }
+	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES3_1); }
 	static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& PermutationParams) { return true; }
 	static void ModifyCompilationEnvironment(const FGlobalShaderPermutationParameters& Parameters, FShaderCompilerEnvironment& OutEnvironment);
-	virtual bool Serialize(FArchive& Ar) override;
 };
 
 
@@ -27,16 +26,15 @@ public:
 	FSketchShaderPS() {}
 	explicit FSketchShaderPS(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
 
-	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES2); }
+	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES3_1); }
 	static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& PermutationParams) { return true; }
 	static void ModifyCompilationEnvironment(const FGlobalShaderPermutationParameters& Parameters, FShaderCompilerEnvironment& OutEnvironment);
-	virtual bool Serialize(FArchive& Ar) override;
 };
 
 struct FSketchVertex
 {
-    FVector4    Position;
-    FVector2D   UV;
+    FVector4f    Position;
+    FVector2f   UV;
 };
 
 class FSketchVertexDeclaration : public FRenderResource

--- a/UsfPluginProject/UsfPluginProject.uproject
+++ b/UsfPluginProject/UsfPluginProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.22",
+	"EngineAssociation": "5.0",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/UsfProject/Source/ShaderModule/ShaderModule.cpp
+++ b/UsfProject/Source/ShaderModule/ShaderModule.cpp
@@ -5,7 +5,7 @@
 
 void FShaderModule::StartupModule()
 {
-#if (ENGINE_MINOR_VERSION >= 21)    
+#if (ENGINE_MINOR_VERSION >= 21 || ENGINE_MAJOR_VERSION >= 5)    
     FString ShaderDirectory = FPaths::Combine(FPaths::ProjectDir(), TEXT("Shader"));
     if(!AllShaderSourceDirectoryMappings().Contains("/Project"))
         AddShaderSourceDirectoryMapping("/Project", ShaderDirectory);

--- a/UsfProject/Source/ShaderModule/SketchComponent.cpp
+++ b/UsfProject/Source/ShaderModule/SketchComponent.cpp
@@ -1,6 +1,7 @@
 #include "SketchComponent.h"
 #include "SketchShader.h"
-#include "Classes/Engine/TextureRenderTarget2D.h"  
+#include "Engine/TextureRenderTarget2D.h"  
+#include "RHI.h"
 //#include "RHICommandList.h" // RHI module
 #include "RHIResources.h"
 
@@ -58,18 +59,18 @@ void USketchComponent::ExecuteInRenderThread(FRHICommandListImmediate& RHICmdLis
     RHICmdList.ApplyCachedRenderTargets(PSOInitializer);
 	PSOInitializer.PrimitiveType = PT_TriangleList;
     PSOInitializer.BoundShaderState.VertexDeclarationRHI = VertexDec.VertexDeclarationRHI;
-	PSOInitializer.BoundShaderState.VertexShaderRHI = GETSAFERHISHADER_VERTEX(*shaderVS);
-    PSOInitializer.BoundShaderState.PixelShaderRHI = GETSAFERHISHADER_PIXEL(*shaderPS);
+	PSOInitializer.BoundShaderState.VertexShaderRHI = shaderVS.GetVertexShader();
+	PSOInitializer.BoundShaderState.PixelShaderRHI = shaderPS.GetPixelShader();
 	PSOInitializer.RasterizerState = TStaticRasterizerState<FM_Solid, CM_None>::GetRHI();
 	PSOInitializer.BlendState = TStaticBlendState<>::GetRHI();
 	PSOInitializer.DepthStencilState = TStaticDepthStencilState<false, CF_Always>::GetRHI();
-	SetGraphicsPipelineState(RHICmdList, PSOInitializer);
+	SetGraphicsPipelineState(RHICmdList, PSOInitializer, 0);
 
 	static const FSketchVertex Vertices[4] = {
-		{ FVector4(-1.0f,  1.0f, 0.0f, 1.0f), FVector2D(0.0f, 0.0f)},
-		{ FVector4( 1.0f,  1.0f, 0.0f, 1.0f), FVector2D(1.0f, 0.0f)},
-		{ FVector4(-1.0f, -1.0f, 0.0f, 1.0f), FVector2D(0.0f, 1.0f)},
-		{ FVector4( 1.0f, -1.0f, 0.0f, 1.0f), FVector2D(1.0f, 1.0f)},
+		{ FVector4f(-1.0f,  1.0f, 0.0f, 1.0f), FVector2f(0.0f, 0.0f)},
+		{ FVector4f( 1.0f,  1.0f, 0.0f, 1.0f), FVector2f(1.0f, 0.0f)},
+		{ FVector4f(-1.0f, -1.0f, 0.0f, 1.0f), FVector2f(0.0f, 1.0f)},
+		{ FVector4f( 1.0f, -1.0f, 0.0f, 1.0f), FVector2f(1.0f, 1.0f)},
 	};
 	
 	static const uint16 Indices[6] =
@@ -78,7 +79,7 @@ void USketchComponent::ExecuteInRenderThread(FRHICommandListImmediate& RHICmdLis
 		2, 1, 3
 	};
 
-	DrawIndexedPrimitiveUP(RHICmdList, PT_TriangleList, 0, ARRAY_COUNT(Vertices), 2, Indices, sizeof(Indices[0]), Vertices, sizeof(Vertices[0]));
+	DrawIndexedPrimitiveUP(RHICmdList, PT_TriangleList, 0, UE_ARRAY_COUNT(Vertices), 2, Indices, sizeof(Indices[0]), Vertices, sizeof(Vertices[0]));
 
     // Resolve render target.  
     RHICmdList.CopyToResolveTarget(  
@@ -102,16 +103,16 @@ void USketchComponent::DrawIndexedPrimitiveUP(
 {
 	const uint32 NumIndices = GetVertexCountForPrimitiveCount( NumPrimitives, PrimitiveType );
 
-	FRHIResourceCreateInfo CreateInfo;
-	FVertexBufferRHIRef VertexBufferRHI = RHICreateVertexBuffer(VertexDataStride * NumVertices, BUF_Volatile, CreateInfo);
-	void* VoidPtr = RHILockVertexBuffer(VertexBufferRHI, 0, VertexDataStride * NumVertices, RLM_WriteOnly);
+	FRHIResourceCreateInfo CreateInfo(TEXT("FRHIResourceCreateInfo"));
+	FBufferRHIRef VertexBufferRHI = RHICreateVertexBuffer(VertexDataStride * NumVertices, BUF_Volatile, CreateInfo);
+	void* VoidPtr = RHILockBuffer(VertexBufferRHI, 0, VertexDataStride * NumVertices, RLM_WriteOnly);
 	FPlatformMemory::Memcpy(VoidPtr, VertexData, VertexDataStride * NumVertices);
-	RHIUnlockVertexBuffer(VertexBufferRHI);
+	RHIUnlockBuffer(VertexBufferRHI);
 
-	FIndexBufferRHIRef IndexBufferRHI = RHICreateIndexBuffer(IndexDataStride, IndexDataStride * NumIndices, BUF_Volatile, CreateInfo);
-	void* VoidPtr2 = RHILockIndexBuffer(IndexBufferRHI, 0, IndexDataStride * NumIndices, RLM_WriteOnly);
+	FBufferRHIRef IndexBufferRHI = RHICreateIndexBuffer(IndexDataStride, IndexDataStride * NumIndices, BUF_Volatile, CreateInfo);
+	void* VoidPtr2 = RHILockBuffer(IndexBufferRHI, 0, IndexDataStride * NumIndices, RLM_WriteOnly);
 	FPlatformMemory::Memcpy(VoidPtr2, IndexData, IndexDataStride * NumIndices);
-	RHIUnlockIndexBuffer(IndexBufferRHI);
+	RHIUnlockBuffer(IndexBufferRHI);
 
 	RHICmdList.SetStreamSource(0, VertexBufferRHI, 0);
 	RHICmdList.DrawIndexedPrimitive(IndexBufferRHI, MinVertexIndex, 0, NumVertices, 0, NumPrimitives, 1);

--- a/UsfProject/Source/ShaderModule/SketchShader.cpp
+++ b/UsfProject/Source/ShaderModule/SketchShader.cpp
@@ -1,4 +1,5 @@
 #include "SketchShader.h"
+#include <Runtime/RenderCore/Public/ShaderCompilerCore.h>
 
 
 FSketchShaderVS::FSketchShaderVS(const ShaderMetaType::CompiledShaderInitializerType& Initializer)
@@ -12,13 +13,6 @@ void FSketchShaderVS::ModifyCompilationEnvironment(const FGlobalShaderPermutatio
 	OutEnvironment.CompilerFlags.Add(CFLAG_StandardOptimization);
 }
 
-bool FSketchShaderVS::Serialize(FArchive& Ar)
-{
-    return FGlobalShader::Serialize(Ar);
-}
-
-
-
 FSketchShaderPS::FSketchShaderPS(const ShaderMetaType::CompiledShaderInitializerType& Initializer)
 	: FGlobalShader(Initializer)
 {
@@ -28,11 +22,6 @@ void FSketchShaderPS::ModifyCompilationEnvironment(const FGlobalShaderPermutatio
 {
 	FGlobalShader::ModifyCompilationEnvironment(Parameters, OutEnvironment);
 	OutEnvironment.CompilerFlags.Add(CFLAG_StandardOptimization);
-}
-
-bool FSketchShaderPS::Serialize(FArchive& Ar)
-{
-    return FGlobalShader::Serialize(Ar);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/UsfProject/Source/ShaderModule/SketchShader.h
+++ b/UsfProject/Source/ShaderModule/SketchShader.h
@@ -12,11 +12,9 @@ public:
 	FSketchShaderVS() {}
 	explicit FSketchShaderVS(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
 
-	static bool ShouldCache(EShaderPlatform Platform) { return true; }
-	//static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES2); }
+	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES3_1); }
 	static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& PermutationParams) { return true; }
 	static void ModifyCompilationEnvironment(const FGlobalShaderPermutationParameters& Parameters, FShaderCompilerEnvironment& OutEnvironment);
-	virtual bool Serialize(FArchive& Ar) override;
 };
 
 
@@ -28,17 +26,15 @@ public:
 	FSketchShaderPS() {}
 	explicit FSketchShaderPS(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
 
-	static bool ShouldCache(EShaderPlatform Platform) { return true; }
-	//static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES2); }
+	static bool ShouldCache(EShaderPlatform Platform) { return IsFeatureLevelSupported(Platform, ERHIFeatureLevel::ES3_1); }
 	static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& PermutationParams) { return true; }
 	static void ModifyCompilationEnvironment(const FGlobalShaderPermutationParameters& Parameters, FShaderCompilerEnvironment& OutEnvironment);
-	virtual bool Serialize(FArchive& Ar) override;
 };
 
 struct FSketchVertex
 {
-    FVector4    Position;
-    FVector2D   UV;
+    FVector4f    Position;
+    FVector2f   UV;
 };
 
 class FSketchVertexDeclaration : public FRenderResource

--- a/UsfProject/UsfProject.uproject
+++ b/UsfProject/UsfProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.22",
+	"EngineAssociation": "5.0",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
プロジェクトをUE5.0にアップグレードし、Deprecated警告が出た箇所を修正しました。
また、FVector等の型がfloat→doubleに変更された影響によりRenderTargetに描画されない問題を修正しました。
5.0.2で動作する事を確認しております。よろしければマージのほどお願いいたします。